### PR TITLE
Make it possible to "reserve" payment

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -233,4 +233,9 @@ class Shopware_Plugins_Frontend_StripePayment_Bootstrap extends Shopware_Compone
 
         return $pluginJSON;
     }
+
+    public function getStripePaymentMethod()
+    {
+        return new \Shopware\Plugins\StripePayment\Components\StripePaymentMethod();
+    }
 }

--- a/Subscriber/Payment.php
+++ b/Subscriber/Payment.php
@@ -2,6 +2,8 @@
 namespace Shopware\Plugins\StripePayment\Subscriber;
 
 use Enlight\Event\SubscriberInterface;
+use Shopware\Models\Order\Order;
+use Shopware\Plugins\StripePayment\Components\StripePaymentMethod;
 
 /**
  * The subscriber for adding the custom StripePaymentMethod path.
@@ -15,9 +17,10 @@ class Payment implements SubscriberInterface
      */
     public static function getSubscribedEvents()
     {
-        return array(
-            'Shopware_Modules_Admin_InitiatePaymentClass_AddClass' => 'onAddPaymentClass'
-        );
+        return [
+            'Shopware_Modules_Admin_InitiatePaymentClass_AddClass' => 'onAddPaymentClass',
+            'StripePayment_Capture_Order'                          => 'onCaptureOrder',
+        ];
     }
 
     /**
@@ -33,5 +36,14 @@ class Payment implements SubscriberInterface
             $dirs['StripePaymentMethod'] = 'Shopware\Plugins\StripePayment\Components\StripePaymentMethod';
             $args->setReturn($dirs);
         }
+    }
+
+    public function onCaptureOrder(\Enlight_Event_EventArgs $args)
+    {
+        /** @var Order $order */
+        $order = $args->getReturn();
+        $stripePaymentMethod = new StripePaymentMethod();
+        $result = $stripePaymentMethod->captureOrder($order);
+        $args->setReturn($result);
     }
 }


### PR DESCRIPTION
Sometimes it is necessary to authorize payment, but not capture.

The underlying Stripe library supports this, but the Shopware plugin does not.
These changes are to enable:
1. authorization without capture
2. capture at a later time
3. releasing authorization for voided transactions.

I tried to minimize the changes necessary.