### PR TITLE
Hide 'steps'-header when accessing credit cards via account menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Next release
+
+### en
+
+* Fixes a display error at the Login page under Shopware 5.3.
+
+### de
+
+* Behebt einen Darstellungfehler beim Login unter Shopware 5.3.
+
 ## 2.2.0
 
 ### en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ### en
 
-* Fixes a display error at the Login page under Shopware 5.3.
+* Fixes a display error in the login when using Shopware 5.3.
 
 ### de
 
-* Behebt einen Darstellungfehler beim Login unter Shopware 5.3.
+* Behebt einen Darstellungsfehler im Login unter Shopware 5.3.
+
 
 ## 2.2.0
 

--- a/Controllers/Frontend/StripePaymentAccount.php
+++ b/Controllers/Frontend/StripePaymentAccount.php
@@ -14,13 +14,12 @@ class Shopware_Controllers_Frontend_StripePaymentAccount extends Shopware_Contro
      */
     public function preDispatch()
     {
-        parent::preDispatch();
-
         // Check if user is logged in
         if (!$this->admin->sCheckUser()) {
             unset($this->View()->sUserData);
-            return $this->forward('login', 'Account');
+            return $this->forward('login', 'account');
         }
+        parent::preDispatch();
     }
 
     /**

--- a/Controllers/Frontend/StripePaymentAccount.php
+++ b/Controllers/Frontend/StripePaymentAccount.php
@@ -15,11 +15,12 @@ class Shopware_Controllers_Frontend_StripePaymentAccount extends Shopware_Contro
     public function preDispatch()
     {
         // Check if user is logged in
-        if (!$this->admin->sCheckUser()) {
+        if ($this->admin->sCheckUser()) {
+            parent::preDispatch();
+        } else {
             unset($this->View()->sUserData);
-            return $this->forward('login', 'account');
+            $this->forward('login', 'account');
         }
-        parent::preDispatch();
     }
 
     /**


### PR DESCRIPTION
A user reported that the 'steps'-header (where the step of the checkouts are shown) is shown when accessing the credit cards via the account menu.