### PR TITLE
Change autoloader from Enlight_Loader to Composer

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -398,11 +398,6 @@ class Shopware_Plugins_Frontend_StripePayment_Bootstrap extends Shopware_Compone
      */
     public function afterInit()
     {
-        $this->get('Loader')->registerNamespace(
-            'Shopware\Plugins\StripePayment',
-            $this->Path()
-        );
-
         // Load the Shopware polyfill
         require_once __DIR__ . '/Polyfill/Loader.php';
     }

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,13 @@
         "phpcs": "vendor/bin/phpcs -s -n .",
         "phpcs:fix": "vendor/bin/phpcbf -s -n .",
         "phplint": "echo \"Linting all PHP files...\"; LINT_RETURN=0; for FILE in $(find . -regex \".*\\.php\" -not -path \"./vendor/*\"); do if ! php -l \"$FILE\"; then LINT_RETURN=1; fi; done; exit $LINT_RETURN;"
+    },
+    "autoload": {
+        "psr-4": {
+            "Shopware\\Plugins\\StripePayment\\": "."
+        },
+        "exclude-from-classmap": [
+            "Polyfill"
+        ]
     }
 }


### PR DESCRIPTION
Any calls to `Enlight_Loader`'s `registerNamespace` and `registerCustomModels` have been removed, if the plugin had any.

All the plugin's class loading is assumed PSR-0 compliant.

_Note:_ Major performance gains are only expected when this package is released passing the `--classmap-authoritative` to composer.