### PR TITLE
Use {$smarty.block.parent} instead of append

### DIFF
--- a/Views/emotion/backend/stripe_payment/index/header.tpl
+++ b/Views/emotion/backend/stripe_payment/index/header.tpl
@@ -1,5 +1,7 @@
 {extends file='parent:backend/index/header.tpl'}
 
-{block name="backend/base/header/css" append}
+{block name="backend/base/header/css"}
+    {$smarty.block.parent}
+    
     <link type="text/css" media="all" rel="stylesheet" href="{link file='backend/stripe_payment/_resources/css/stripe-button.css'}" />
 {/block}

--- a/Views/emotion/backend/stripe_payment/order_detail_position_refund.js
+++ b/Views/emotion/backend/stripe_payment/order_detail_position_refund.js
@@ -8,6 +8,7 @@
 
 //{block name="backend/order/view/detail/position"}
     //{$smarty.block.parent}
+
 Ext.define('Shopware.apps.StripePayment.Order.view.detail.Position', {
 
     override: 'Shopware.apps.Order.view.detail.Position',
@@ -80,6 +81,7 @@ Ext.define('Shopware.apps.StripePayment.Order.view.detail.Position', {
 
 //{block name="backend/order/controller/detail"}
     //{$smarty.block.parent}
+
     // Include the refund model and window
     //{include file="backend/stripe_payment/order_detail_position_refund/item.js"}
     //{include file="backend/stripe_payment/order_detail_position_refund/window.js"}

--- a/Views/emotion/backend/stripe_payment/order_detail_position_refund.js
+++ b/Views/emotion/backend/stripe_payment/order_detail_position_refund.js
@@ -6,7 +6,8 @@
 
 //{namespace name=backend/plugins/stripe_payment/order_detail_position_refund}
 
-//{block name="backend/order/view/detail/position" append}
+//{block name="backend/order/view/detail/position"}
+    //{$smarty.block.parent}
 Ext.define('Shopware.apps.StripePayment.Order.view.detail.Position', {
 
     override: 'Shopware.apps.Order.view.detail.Position',
@@ -77,7 +78,8 @@ Ext.define('Shopware.apps.StripePayment.Order.view.detail.Position', {
 });
 //{/block}
 
-//{block name="backend/order/controller/detail" append}
+//{block name="backend/order/controller/detail"}
+    //{$smarty.block.parent}
     // Include the refund model and window
     //{include file="backend/stripe_payment/order_detail_position_refund/item.js"}
     //{include file="backend/stripe_payment/order_detail_position_refund/window.js"}

--- a/Views/emotion/backend/stripe_payment/order_detail_stripe_dashboard_button.js
+++ b/Views/emotion/backend/stripe_payment/order_detail_stripe_dashboard_button.js
@@ -10,6 +10,7 @@
  */
 //{block name="backend/order/view/detail/overview"}
     //{$smarty.block.parent}
+
 Ext.define('Shopware.apps.StripePayment.Order.view.detail.Overview.StripeDashboardButton', {
 
     override: 'Shopware.apps.Order.view.detail.Overview',

--- a/Views/emotion/backend/stripe_payment/order_detail_stripe_dashboard_button.js
+++ b/Views/emotion/backend/stripe_payment/order_detail_stripe_dashboard_button.js
@@ -8,7 +8,8 @@
  * Overrides the backend order detail overview to provide an extra button
  * for opening Stripe payments in the Stripe dashboard.
  */
-//{block name="backend/order/view/detail/overview" append}
+//{block name="backend/order/view/detail/overview"}
+    //{$smarty.block.parent}
 Ext.define('Shopware.apps.StripePayment.Order.view.detail.Overview.StripeDashboardButton', {
 
     override: 'Shopware.apps.Order.view.detail.Overview',

--- a/Views/emotion/frontend/stripe_payment/account/content_right.tpl
+++ b/Views/emotion/frontend/stripe_payment/account/content_right.tpl
@@ -1,6 +1,8 @@
 {extends file='parent:frontend/account/content_right.tpl'}
 
-{block name='frontend_account_content_right_payment' append}
+{block name='frontend_account_content_right_payment'}
+    {$smarty.block.parent}
+
     {* Add Stripe credit card management *}
     <li>
         <a href="{url controller='StripePaymentAccount' action='manageCreditCards'}">

--- a/Views/emotion/frontend/stripe_payment/checkout/confirm.tpl
+++ b/Views/emotion/frontend/stripe_payment/checkout/confirm.tpl
@@ -1,4 +1,6 @@
-{block name="frontend_index_header_javascript" append}
+{block name="frontend_index_header_javascript"}
+    {$smarty.block.parent}
+
     {if $sUserData.additional.payment.class == "StripePaymentApplePay"}
         {* Include and set up the Stripe SDK *}
         <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
@@ -10,14 +12,18 @@
     {/if}
 {/block}
 
-{block name="frontend_index_header_css_screen" append}
+{block name="frontend_index_header_css_screen"}
+    {$smarty.block.parent}
+
     <style type="text/css">
         {* Include shared CSS for payment provider logo SVGs *}
         {include file="frontend/stripe_payment/_resources/styles/stripe_payment_provider_logos.css"}
     </style>
 {/block}
 
-{block name="frontend_index_content_top" append}
+{block name="frontend_index_content_top"}
+    {$smarty.block.parent}
+
     {if $stripePayment.error}
         <div class="grid_20 first">
             <div class="error">

--- a/Views/responsive/frontend/account/sidebar.tpl
+++ b/Views/responsive/frontend/account/sidebar.tpl
@@ -1,6 +1,8 @@
 {extends file="parent:frontend/account/sidebar.tpl"}
 
-{block name="frontend_account_menu_link_payment" append}
+{block name="frontend_account_menu_link_payment"}
+    {$smarty.block.parent}
+
     <li class="navigation--entry">
         <a href="{url controller='StripePaymentAccount' action='manageCreditCards'}" title="{s namespace='frontend/plugins/stripe_payment/account' name='credit_cards/title'}{/s}" class="navigation--link{if $sAction == 'manageCreditCards'} is--active{/if}">
             {s namespace='frontend/plugins/stripe_payment/account' name='credit_cards/title'}{/s}

--- a/Views/responsive/frontend/account/stripe_payment_credit_cards.tpl
+++ b/Views/responsive/frontend/account/stripe_payment_credit_cards.tpl
@@ -3,7 +3,9 @@
 {namespace name='frontend/plugins/stripe_payment/account'}
 
 {* Breadcrumb *}
-{block name="frontend_index_start" append}
+{block name="frontend_index_start"}
+    {$smarty.block.parent}
+
     {$sBreadcrumb[] = ["name" => "{s name='credit_cards/title'}{/s}", "link" => {url}]}
 {/block}
 

--- a/Views/responsive/frontend/checkout/confirm.tpl
+++ b/Views/responsive/frontend/checkout/confirm.tpl
@@ -1,6 +1,8 @@
 {extends file="parent:frontend/checkout/confirm.tpl"}
 
-{block name="frontend_checkout_confirm_error_messages" append}
+{block name="frontend_checkout_confirm_error_messages"}
+    {$smarty.block.parent}
+
     {include file="frontend/checkout/stripe_payment_error.tpl"}
 
     {if $sUserData.additional.payment.class == "StripePaymentApplePay"}
@@ -14,7 +16,9 @@
     {/if}
 {/block}
 
-{block name="frontend_index_header_javascript_jquery" append}
+{block name="frontend_index_header_javascript_jquery"}
+    {$smarty.block.parent}
+
     {if ($sUserData.additional.payment.class == "StripePaymentCard" && $stripePayment.selectedCard) || ($sUserData.additional.payment.class == "StripePaymentSepa" && $stripePayment.sepaSource)}
         <script type="text/javascript">
             document.stripeJQueryReady(function() {

--- a/Views/responsive/frontend/checkout/shipping_payment.tpl
+++ b/Views/responsive/frontend/checkout/shipping_payment.tpl
@@ -1,13 +1,17 @@
 {extends file="parent:frontend/checkout/shipping_payment.tpl"}
 
-{block name="frontend_index_header" append}
+{block name="frontend_index_header"}
+    {$smarty.block.parent}
+
     <style type="text/css">
         {* Include shared CSS for payment provider logo SVGs *}
         {include file="frontend/stripe_payment/_resources/styles/stripe_payment_provider_logos.css"}
     </style>
 {/block}
 
-{block name="frontend_index_header_javascript_jquery" append}
+{block name="frontend_index_header_javascript_jquery"}
+    {$smarty.block.parent}
+
     <script type="text/javascript" src="https://js.stripe.com/v2/"></script>
     <script type="text/javascript" src="https://js.stripe.com/v3/"></script>
     <script type="text/javascript">

--- a/Views/responsive/frontend/checkout/shipping_payment_core.tpl
+++ b/Views/responsive/frontend/checkout/shipping_payment_core.tpl
@@ -1,5 +1,7 @@
 {extends file="parent:frontend/checkout/shipping_payment_core.tpl"}
 
-{block name="frontend_checkout_shipping_payment_core_payment_fields" prepend}
+{block name="frontend_checkout_shipping_payment_core_payment_fields"}
     {include file="frontend/checkout/stripe_payment_error.tpl"}
+    
+    {$smarty.block.parent}
 {/block}

--- a/Views/responsive/frontend/index/index.tpl
+++ b/Views/responsive/frontend/index/index.tpl
@@ -1,6 +1,8 @@
 {extends file="parent:frontend/index/index.tpl"}
 
-{block name="frontend_index_header_javascript" append}
+{block name="frontend_index_header_javascript"}
+    {$smarty.block.parent}
+
     <script type="text/javascript">
         if (typeof document.asyncReady === 'function') {
             // Shopware >= 5.3, hence wait for async JavaScript first
@@ -18,7 +20,7 @@
     </script>
 {/block}
 
-{block name="frontend_index_javascript_async_ready" prepend}
+{block name="frontend_index_javascript_async_ready"}
     {* This block is only loaded in Shopware >= 5.3 *}
     <script type="text/javascript">
         (function () {
@@ -40,4 +42,6 @@
             }
         })();
     </script>
+
+    {$smarty.block.parent}
 {/block}


### PR DESCRIPTION
In order to support better extensibility for themes or plugins the `append`/`prepend` keywords in smarty blocks should not be used. Replaced them with `{$smarty.block.parent}` calls inside the blocks to reference the parent content of the block.

Fixes #35 