### PR TITLE
Remove hardscoded euro signs to support other currencies.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /vendor/
+.idea

--- a/Controllers/Backend/StripePayment.php
+++ b/Controllers/Backend/StripePayment.php
@@ -97,13 +97,13 @@ class Shopware_Controllers_Backend_StripePayment extends Shopware_Controllers_Ba
         $internalComment = $order->getInternalComment();
         $internalComment .= "\n--------------------------------------------------------------\n"
                          . 'Stripe Rückerstattung (' . date('d.m.Y, G:i:s') . ")\n"
-                         . 'Betrag: ' . number_format($amount, 2, ',', '.') . " €\n"
+                         . 'Betrag: ' . number_format($amount, 2, ',', '.') . " CHF\n"
                          . 'Kommentar: ' . $comment . "\n"
                          . "Positionen:\n";
         foreach ($positions as $position) {
             $price = number_format($position['price'], 2, ',', '.');
             $totalPrice = number_format($position['total'], 2, ',', '.');
-            $internalComment .= ' - ' . $position['quantity'] . ' x ' . $position['articleNumber'] . ', je ' . $price . ' €, Gesamt: ' . $totalPrice . " €\n";
+            $internalComment .= ' - ' . $position['quantity'] . ' x ' . $position['articleNumber'] . ', je ' . $price . ' CHF, Gesamt: ' . $totalPrice . " CHF\n";
         }
         $internalComment .= "--------------------------------------------------------------\n";
         $order->setInternalComment($internalComment);

--- a/Views/backend/stripe_payment/order_detail_position_refund.js
+++ b/Views/backend/stripe_payment/order_detail_position_refund.js
@@ -166,7 +166,7 @@ Ext.define('Shopware.apps.StripePayment.Order.controller.Detail', {
         });
         refundWindow.total = newOverallTotal;
         refundWindow.form.getForm().setValues({
-            total: Ext.util.Format.currency(newOverallTotal, ' &euro;', 2, true)
+            total: Ext.util.Format.currency(newOverallTotal, '', 2, true)
         });
     },
 

--- a/Views/backend/stripe_payment/order_detail_position_refund/window.js
+++ b/Views/backend/stripe_payment/order_detail_position_refund/window.js
@@ -105,7 +105,7 @@ Ext.define('Shopware.apps.StripePayment.Order.view.detail.position.refund.Window
                 align: 'right',
                 flex: 1,
                 renderer: function(value, metaData, record) {
-                    return Ext.util.Format.number(value, '0.000,00 €/i');
+                    return Ext.util.Format.number(value, '0,000.00/i');
                 }
             }, {
                 xtype: 'gridcolumn',
@@ -114,7 +114,7 @@ Ext.define('Shopware.apps.StripePayment.Order.view.detail.position.refund.Window
                 align: 'right',
                 flex: 1,
                 renderer: function(value, metaData, record) {
-                    return Ext.util.Format.number(value, '0.000,00 €/i');
+                    return Ext.util.Format.number(value, '0,000.00/i');
                 }
             }],
             plugins: [
@@ -149,7 +149,7 @@ Ext.define('Shopware.apps.StripePayment.Order.view.detail.position.refund.Window
                     xtype: 'displayfield',
                     fieldLabel: '{s name=order/view/detail/position/refund/window/form/total_amount}{/s}',
                     name: 'total',
-                    value: Ext.util.Format.currency(this.total, ' &euro;', 2, true)
+                    value: Ext.util.Format.currency(this.total, '', 2, true)
                 }, {
                     xtype: 'textfield',
                     fieldLabel: '{s name=order/view/detail/position/refund/window/form/comment}{/s}',


### PR DESCRIPTION
Not all countries and companies have euro as a default currency. Please remove all the hardcoded Euro signs, as it is very disturbing if the order was done in CHF (Swiss Francs) and the refunds show Euro.