### PR TITLE
Ensure we enable the credit card management link at all times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 ### en
 
 * The plugin now complies with Strong Customer Authentication (SCA).
-* Fixes an error that might have caused the credit card management in the account overview to be hidden.
+* Fixes a bug that could prevent the credit card management from being visible in the account overview.
 
 ### de
 
 * Das Plugin erfüllt nun die Anforderungen für Strong Customer Authentication (SCA).
-* Behebt einen Fehler, der unter Umständen dazu geführt hat, dass die Kreditkartenverwaltung in der Kontoübersicht ausgeblendet wurde.
+* Behebt einen Fehler, der unter Umständen dazu führte, dass die Kreditkartenverwaltung nicht in der Kontoübersicht angezeigt wurde.
 
 
 ## 4.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 ### en
 
 * The plugin now complies with Strong Customer Authentication (SCA).
+* Fixes an error that might have caused the credit card management in the account overview to be hidden.
 
 ### de
 
 * Das Plugin erfüllt nun die Anforderungen für Strong Customer Authentication (SCA).
+* Behebt einen Fehler, der unter Umständen dazu geführt hat, dass die Kreditkartenverwaltung in der Kontoübersicht ausgeblendet wurde.
 
 
 ## 4.0.0

--- a/Subscriber/Frontend/Account.php
+++ b/Subscriber/Frontend/Account.php
@@ -35,6 +35,8 @@ class Account implements SubscriberInterface
     {
         return [
             'Enlight_Controller_Action_PostDispatchSecure_Frontend_Account' => 'onPostDispatchSecure',
+            'Enlight_Controller_Action_PostDispatchSecure_Frontend_StripePaymentAccount' => 'onPostDispatchSecure',
+            'Enlight_Controller_Action_PostDispatchSecure_Widgets_Checkout' => 'onPostDispatchSecure',
         ];
     }
 


### PR DESCRIPTION
This PR fixes the missing credit card management link when clicking on it itself and on the account dropdown at the top right. This is done by adding the missing events and thus ensuring the config variable is set for these.

Fixes #45 