### PR TITLE
Add order number to charges description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## NEXT PATCH RELEASE
+
+### en
+
+* Fixes a bug which could prevent the order number to be appended to the charges description.
+
+### de
+
+* Behebt einen Fehler, der unter Umständen dazu führte, dass die Bestellnummer nicht an die Transaktionen angehängt wurde.
+
+
 ## 5.1.0
 
 ### en

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### en
 
-* Fixes a bug which could prevent the order number to be appended to the charges description.
+* Fixes a bug that prevent the order number from being added to the description of credit card transactions.
 
 ### de
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### de
 
-* Behebt einen Fehler, der unter Umständen dazu führte, dass die Bestellnummer nicht an die Transaktionen angehängt wurde.
+* Behebt einen Fehler, der dazu führte, dass der Beschreibung von Kreditkarten-Transaktionen nicht die Bestellnummer hinzugefügt wurde.
 
 
 ## 5.1.0

--- a/Controllers/Frontend/StripePayment.php
+++ b/Controllers/Frontend/StripePayment.php
@@ -289,7 +289,7 @@ class Shopware_Controllers_Frontend_StripePayment extends Shopware_Controllers_F
                 [
                     'exception' => $e,
                     'trace' => $e->getTrace(),
-                    'paymentIntendId' => $charge->id,
+                    'chargeId' => $charge->id,
                     'orderId' => $order->getId(),
                 ]
             );

--- a/Controllers/Frontend/StripePayment.php
+++ b/Controllers/Frontend/StripePayment.php
@@ -283,9 +283,16 @@ class Shopware_Controllers_Frontend_StripePayment extends Shopware_Controllers_F
             // Save the order number in the charge description
             $charge->description .= ' / Order ' . $orderNumber;
             $charge->save();
-        } catch (Exception $e) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCATCH
-            // Ignore exceptions in this case, because the order has already been created
-            // and adding the order number is not essential for identifying the payment
+        } catch (Exception $e) {
+            $this->get('pluginlogger')->error(
+                'StripePayment: Failed to update charge description with order number',
+                [
+                    'exception' => $e,
+                    'trace' => $e->getTrace(),
+                    'paymentIntendId' => $charge->id,
+                    'orderId' => $order->getId(),
+                ]
+            );
         }
 
         return $order;

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -199,7 +199,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         }
 
         try {
-            // Save the order number in the payment intends charge description
+            // Save the order number in the payment intent's charge description
             $charge->description .= ' / Order ' . $orderNumber;
             $charge->save();
         } catch (Exception $e) {

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -204,7 +204,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
             $charge->save();
         } catch (Exception $e) {
             $this->get('pluginlogger')->error(
-                'StripePayment: Failed to update the payment intends charge description with order number',
+                'StripePayment: Failed to update the payment intent\'s charge description with order number',
                 [
                     'exception' => $e,
                     'trace' => $e->getTrace(),

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -177,7 +177,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
                 [
                     'exception' => $e,
                     'trace' => $e->getTrace(),
-                    'paymentIntendId' => $paymentIntent->id,
+                    'paymentIntentId' => $paymentIntent->id,
                     'orderId' => $order->getId(),
                 ]
             );

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -208,7 +208,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
                 [
                     'exception' => $e,
                     'trace' => $e->getTrace(),
-                    'paymentIntendId' => $paymentIntent->id,
+                    'paymentIntentId' => $paymentIntent->id,
                     'chargeId' => $charge->id,
                     'orderId' => $order->getId(),
                 ]

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -186,7 +186,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         $charge = count($paymentIntent->charges->data) > 0 ? $paymentIntent->charges->data[0] : null;
         if (!$charge) {
             $this->get('pluginlogger')->error(
-                'StripePayment: No charge found for payment intend',
+                'StripePayment: No charge found for payment intent',
                 [
                     'exception' => $e,
                     'trace' => $e->getTrace(),

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -190,7 +190,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
                 [
                     'exception' => $e,
                     'trace' => $e->getTrace(),
-                    'paymentIntendId' => $paymentIntent->id,
+                    'paymentIntentId' => $paymentIntent->id,
                     'orderId' => $order->getId(),
                 ]
             );

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -199,8 +199,8 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         }
 
         try {
-            // Save the order number in the payment intent's charge description
-            $charge->description .= ' / Order ' . $orderNumber;
+            // Update the charge description from the payment intent
+            $charge->description = $paymentIntent->description;
             $charge->save();
         } catch (Exception $e) {
             $this->get('pluginlogger')->error(

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -168,7 +168,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
         $this->get('models')->flush($order);
 
         try {
-            // Save the order number in the payment intend description
+            // Save the order number in the payment intent description
             $paymentIntent->description .= ' / Order ' . $orderNumber;
             $paymentIntent->save();
         } catch (Exception $e) {

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -173,7 +173,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
             $paymentIntent->save();
         } catch (Exception $e) {
             $this->get('pluginlogger')->error(
-                'StripePayment: Failed to update payment intend description with order number',
+                'StripePayment: Failed to update payment intent description with order number',
                 [
                     'exception' => $e,
                     'trace' => $e->getTrace(),

--- a/Controllers/Frontend/StripePaymentIntent.php
+++ b/Controllers/Frontend/StripePaymentIntent.php
@@ -191,6 +191,7 @@ class Shopware_Controllers_Frontend_StripePaymentIntent extends Shopware_Control
                     'exception' => $e,
                     'trace' => $e->getTrace(),
                     'paymentIntendId' => $paymentIntent->id,
+                    'orderId' => $order->getId(),
                 ]
             );
 


### PR DESCRIPTION
This PR adds the order number to the charges description for payment intend created charges. In case there are errors when updating the description(s), these are now logged via the plugin logger.

Closes #55 